### PR TITLE
bpfhv: implement upgrade file descriptor for proxy upgrade requests

### DIFF
--- a/include/bpfhv/netproxy.h
+++ b/include/bpfhv/netproxy.h
@@ -41,6 +41,7 @@ int bpfhv_proxy_set_queue_kickfd(struct BpfhvProxyState *s,
                                  unsigned int queue_idx, int fd);
 int bpfhv_proxy_set_queue_irqfd(struct BpfhvProxyState *s,
                                 unsigned int queue_idx, int fd);
+int bpfhv_proxy_set_upgradefd(struct BpfhvProxyState *s, int fd);
 int bpfhv_proxy_enable(struct BpfhvProxyState *s, bool is_rx, bool enable);
 
 #endif  /* __BPFHV_NETPROXY_H__ */

--- a/net/bpfhv-proxy.c
+++ b/net/bpfhv-proxy.c
@@ -421,6 +421,26 @@ bpfhv_proxy_set_queue_irqfd(BpfhvProxyState *s, unsigned int queue_idx,
 }
 
 int
+bpfhv_proxy_set_upgradefd(struct BpfhvProxyState *s, int fd)
+{
+    BpfhvProxyMessage msg;
+    int ret;
+
+    memset(&msg, 0, sizeof(msg));
+    msg.hdr.reqtype = BPFHV_PROXY_REQ_SET_UPGRADE;
+    msg.hdr.size = sizeof(msg.payload.notify);
+
+    ret = bpfhv_proxy_sendrecv(s, &msg, &fd, 1);
+    if (ret) {
+        return ret;
+    }
+
+    DBG("Set upgradefd to %d", fd);
+
+    return 0;
+}
+
+int
 bpfhv_proxy_enable(BpfhvProxyState *s, bool is_rx, bool enable)
 {
     BpfhvProxyMessage msg;


### PR DESCRIPTION
Bpfhv proxy backend implements upgradefd control messages but proxy upgrade was not implemented in qemu device, so upgradefd was never set.

Tested with guest + proxy backend in server mode with periodic upgrade (3-4 seconds) while guest was generating traffic.